### PR TITLE
Make pytest a development-only dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,15 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = [
-    "pytest>=8.3.5",
-]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]
 
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -105,11 +105,15 @@ wheels = [
 
 [[package]]
 name = "udi-grammar-py"
-version = "0.1.1"
+version = "0.2.1"
 source = { editable = "." }
-dependencies = [
+
+[package.dev-dependencies]
+dev = [
     { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", specifier = ">=8.3.5" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.5" }]


### PR DESCRIPTION
Moves `pytest` from `project.dependencies` to the `dev` [`dependency-group`](https://peps.python.org/pep-0735/). This change keeps it out of the published package requirements (so end-users don't install `pytest` with `pip install`) while still being available during development (enabled [by default in uv](https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies)).

To add dependencies directly to this special group ("dev"), you can use the `--dev` flag.

```sh
uv add --dev pytest
```

Similar to yarn/pnpm/npm "devDependencies".

